### PR TITLE
allow empty rash programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Racket-generated files
 compiled
 doc
 
+# Editor-generated files
+*~

--- a/linea/private/line-macro-definitions.rkt
+++ b/linea/private/line-macro-definitions.rkt
@@ -82,11 +82,12 @@
 
 (define-for-syntax (with-default-line-macro* stx #:context [context #f])
   (syntax-parse stx
-    [(orig-macro let-form new-default:line-macro e ...+)
+    [(orig-macro let-form new-default:line-macro e ...)
      (define default-line-macro-stx
        (or (and context (dlm context #'orig-macro))
            (let ([dlms (map (λ (x) (dlm x #'orig-macro))
-                            (syntax->list #'(e ...)))])
+                            (cond [(null? (attribute e)) (list #'here)]
+                                  [else (attribute e)]))])
              (unless (for/and ([x (cdr dlms)])
                        (bound-identifier=? (car dlms) x))
                (raise-syntax-error

--- a/rash/private/lang-funcs.rkt
+++ b/rash/private/lang-funcs.rkt
@@ -105,7 +105,7 @@
 
 (define-syntax (rash-expressions-begin stx)
   (syntax-parse stx
-    [(_ (input output err-output default-starter line-macro) e ...+)
+    [(_ (input output err-output default-starter line-macro) e ...)
      #`(splicing-let ([in-eval input]
                       [out-eval output]
                       [err-eval err-output])
@@ -128,11 +128,12 @@
        (~optional (~seq #:starter starter:pipeline-starter))
        (~optional (~seq #:line-macro line-macro:line-macro)))
       ...
-      body:expr ...+)
+      body:expr ...)
      (define context-id
        (or (attribute context)
            (let ([cs (map (λ (x) (datum->syntax x '#%app #'orig-macro))
-                          (syntax->list #'(body ...)))])
+                          (cond [(null? (attribute body)) (list #'here)]
+                                [else (attribute body)]))])
              (unless (for/and ([x (cdr cs)])
                        (bound-identifier=? (car cs) x))
                (raise-syntax-error

--- a/rash/private/test/empty-test.rkt
+++ b/rash/private/test/empty-test.rkt
@@ -1,0 +1,1 @@
+#lang rash

--- a/shell-pipeline/private/pipeline-macro-parse.rkt
+++ b/shell-pipeline/private/pipeline-macro-parse.rkt
@@ -105,7 +105,7 @@
            (~optional (~seq #:starter starter:pipeline-starter))
            (~optional (~seq #:context context)))
       ...
-      body:expr ...+)
+      body:expr ...)
      (let* ([set-in (and (attribute in)
                          #'(default-pipeline-in (λ (stx) (quote-syntax in))))]
             [set-out (and (attribute out)
@@ -115,7 +115,8 @@
             [starter-context-id
              (or (attribute context)
                  (let ([cs (map (λ (x) (datum->syntax x '#%app #'orig-macro))
-                                (syntax->list #'(body ...)))])
+                                (cond [(null? (attribute body)) (list #'here)]
+                                      [else (attribute body)]))])
                    (unless (or (not (attribute starter))
                                (for/and ([x (cdr cs)])
                                  (bound-identifier=? (car cs) x)))


### PR DESCRIPTION
This allows "empty" rash programs like
```
#lang rash
```
to run.

The motivation for this is so that scribble code examples could eventually run based on `(make-module-evaluator "#lang rash\n")`, to run the example forms in a REPL generated by the empty rash program.