### PR TITLE
add source locations for linea lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Racket-generated files
 compiled
 doc
 
+# Editor-generated files
+*~

--- a/linea/private/line-macro-definitions.rkt
+++ b/linea/private/line-macro-definitions.rkt
@@ -82,11 +82,12 @@
 
 (define-for-syntax (with-default-line-macro* stx #:context [context #f])
   (syntax-parse stx
-    [(orig-macro let-form new-default:line-macro e ...+)
+    [(orig-macro let-form new-default:line-macro e ...)
      (define default-line-macro-stx
        (or (and context (dlm context #'orig-macro))
            (let ([dlms (map (λ (x) (dlm x #'orig-macro))
-                            (syntax->list #'(e ...)))])
+                            (cond [(null? (attribute e)) (list #'here)]
+                                  [else (attribute e)]))])
              (unless (for/and ([x (cdr dlms)])
                        (bound-identifier=? (car dlms) x))
                (raise-syntax-error

--- a/linea/read.rkt
+++ b/linea/read.rkt
@@ -91,6 +91,9 @@
 
 (define (linea-read-one-line src in outer-linea-read-func end-delim)
   ;; the current-readtable must already be parameterized to the line-readtable
+
+  (define-values [ln col pos] (port-next-location in))
+  
   (define (reverse/filter-newlines rlist)
     ;; Reverse the list, but also:
     ;; Filter out any newline symbols, and transform any symbols that
@@ -115,13 +118,16 @@
     (rec rlist '()))
 
   (define (finalize rlist)
+    (define-values [_1 _2 end] (port-next-location in))
     (if (null? rlist)
         ;; The list can only be empty if we're in a context where there are
         ;; delimiters and a list is being read.  In that case, return #f
         ;; to signal that there are empty trailing lines in the delimiter.
         #f
-        (datum->syntax #f (cons '#%linea-line
-                                (reverse/filter-newlines rlist)))))
+        (datum->syntax #f
+                       (cons '#%linea-line
+                             (reverse/filter-newlines rlist))
+                       (list src ln col pos (- end pos)))))
 
   (define (rec rlist)
     (read-and-ignore-hspace! in)

--- a/rash/private/lang-funcs.rkt
+++ b/rash/private/lang-funcs.rkt
@@ -105,7 +105,7 @@
 
 (define-syntax (rash-expressions-begin stx)
   (syntax-parse stx
-    [(_ (input output err-output default-starter line-macro) e ...+)
+    [(_ (input output err-output default-starter line-macro) e ...)
      #`(splicing-let ([in-eval input]
                       [out-eval output]
                       [err-eval err-output])
@@ -128,11 +128,12 @@
        (~optional (~seq #:starter starter:pipeline-starter))
        (~optional (~seq #:line-macro line-macro:line-macro)))
       ...
-      body:expr ...+)
+      body:expr ...)
      (define context-id
        (or (attribute context)
            (let ([cs (map (λ (x) (datum->syntax x '#%app #'orig-macro))
-                          (syntax->list #'(body ...)))])
+                          (cond [(null? (attribute body)) (list #'here)]
+                                [else (attribute body)]))])
              (unless (for/and ([x (cdr cs)])
                        (bound-identifier=? (car cs) x))
                (raise-syntax-error

--- a/rash/private/test/empty-test.rkt
+++ b/rash/private/test/empty-test.rkt
@@ -1,0 +1,1 @@
+#lang rash

--- a/shell-pipeline/private/pipeline-macro-parse.rkt
+++ b/shell-pipeline/private/pipeline-macro-parse.rkt
@@ -105,7 +105,7 @@
            (~optional (~seq #:starter starter:pipeline-starter))
            (~optional (~seq #:context context)))
       ...
-      body:expr ...+)
+      body:expr ...)
      (let* ([set-in (and (attribute in)
                          #'(default-pipeline-in (λ (stx) (quote-syntax in))))]
             [set-out (and (attribute out)
@@ -115,7 +115,8 @@
             [starter-context-id
              (or (attribute context)
                  (let ([cs (map (λ (x) (datum->syntax x '#%app #'orig-macro))
-                                (syntax->list #'(body ...)))])
+                                (cond [(null? (attribute body)) (list #'here)]
+                                      [else (attribute body)]))])
                    (unless (or (not (attribute starter))
                                (for/and ([x (cdr cs)])
                                  (bound-identifier=? (car cs) x)))


### PR DESCRIPTION
This commit adds source locations for the `(#%linea-line ....)` syntax objects produced by the `rash` reader.