### PR TITLE
wrap repl begin from #%top-interaction, not current-read-interaction

### DIFF
--- a/rash/demo/rc17-demo-modbeg.rkt
+++ b/rash/demo/rc17-demo-modbeg.rkt
@@ -3,8 +3,9 @@
 (provide
  (all-from-out rash/demo/setup)
 
- (except-out (all-from-out racket/base) #%module-begin)
- (rename-out [basic-rash-module-begin #%module-begin])
+ (except-out (all-from-out racket/base) #%module-begin #%top-interaction)
+ (rename-out [basic-rash-module-begin #%module-begin]
+             [basic-rash-top-interaction #%top-interaction])
  (all-from-out rash)
 
  app
@@ -20,7 +21,7 @@
   syntax/parse
   ))
 
-(define-rash-module-begin basic-rash-module-begin
+(define-rash-module-begin basic-rash-module-begin basic-rash-top-interaction
   #:in (current-input-port)
   #:out (current-output-port)
   #:err (current-error-port)

--- a/rash/private/basic-module-begin.rkt
+++ b/rash/private/basic-module-begin.rkt
@@ -1,14 +1,15 @@
 #lang racket/base
 
 (provide
- (except-out (all-from-out racket/base) #%module-begin)
- (rename-out [basic-rash-module-begin #%module-begin])
+ (except-out (all-from-out racket/base) #%module-begin #%top-interaction)
+ (rename-out [basic-rash-module-begin #%module-begin]
+             [basic-rash-top-interaction #%top-interaction])
  (all-from-out rash)
  )
 
 (require rash)
 
-(define-rash-module-begin basic-rash-module-begin
+(define-rash-module-begin basic-rash-module-begin basic-rash-top-interaction
   #:this-module-path rash/private/basic-module-begin
   ;#:in (current-input-port)
   ;#:out (current-output-port)


### PR DESCRIPTION
This PR changes `rash` to wrap repl forms in `rash-expressions-begin` at expansion time with `#%top-interaction`, instead of wrapping them at read-time with the `current-read-interaction` parameter.

It does this by changing `define-rash-module-begin` to define both a `module-begin` macro and `top-interaction` macro.

Also after this pull request, simple `rash` programs can work with `scribble-code-examples`:
```racket
#lang scribble/manual
@(require scribble-code-examples)

@title{Example of rash shown with scribble-code-examples}

@code-examples[#:lang "rash" #:context #'here]|{
cd ..
ls
|> list 1 2 3 |> apply +
}|
```