### PR TITLE
add git-current-commit function

### DIFF
--- a/rash/prompt-helpers/git-info.rkt
+++ b/rash/prompt-helpers/git-info.rkt
@@ -10,6 +10,7 @@
  git-submodule-dirty?
  git-has-untracked?
  git-remote-tracking?
+ git-current-commit
  )
 
 (require
@@ -68,6 +69,10 @@
     (parameterize ([current-directory dir])
       #{git rev-parse --abbrev-ref '"@{upstream}" &pipeline-ret}))
   (pipeline-success? pline))
+
+(define (git-current-commit [dir (current-directory)])
+  (parameterize ([current-directory dir])
+    #{git rev-parse HEAD}))
 
 (define (git-dirty? [dir (current-directory)])
   (define pline

--- a/rash/scribblings/rash.scrbl
+++ b/rash/scribblings/rash.scrbl
@@ -646,6 +646,11 @@ You can use them with @tt{(require rash/prompt-helpers/git-info)}
  Determines if current branch is tracking a remote branch.
 }
 
+@defproc[(git-current-commit [dir path? (current-directory)])
+         string?]{
+ Return the current commit.
+}
+
 @defproc[(git-behind/ahead-numbers [dir path? (current-directory)])
          list?]{
  Returns a list with the number of commits behind and ahead, in that order, that the current branch is in relation to its corresponding upstream branch.


### PR DESCRIPTION
Implemented using [common internet knowledge](https://stackoverflow.com/questions/949314/how-to-retrieve-the-hash-for-the-current-commit-in-git) and also because I'm using it in a rash script so, I think this could be a useful addition to the lib.

Thanks for rash!