### PR TITLE
Install note: readline-gpl needs libreadline-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ use `raco pkg install --clone rash`
 
 #### Readline
 
-The Rash REPL currently relies on Racket's Readline FFI wrapper.  However, by default Racket uses libedit instead of libreadline for licensing reasons.  Libedit does not support unicode, so typing non-ASCII characters will result in sadness.  To use libreadline instead, run `raco pkg install readline-gpl`.
+The Rash REPL currently relies on Racket's Readline FFI wrapper.  However, by default Racket uses libedit instead of libreadline for licensing reasons.  Libedit does not support unicode, so typing non-ASCII characters will result in sadness.  To use libreadline instead, run `raco pkg install readline-gpl`. Note: `readline-gpl` may need `libreadline-dev` in turn. See this [issue](https://github.com/racket/readline-gpl/issues/3). (On Linux-Debian distributions you can install by `sudo apt install --yes libreadline-dev`.)
 
 
 ### Usage

--- a/rash/scribblings/rash.scrbl
+++ b/rash/scribblings/rash.scrbl
@@ -504,7 +504,8 @@ A few nice things (like stderr highlighting) are in a demo-rc file you can requi
 
 @subsection{Unicode and garbled glyphs}
 
-The repl uses the readline module for line-editing and completion.  The readline module by default uses libedit instead of the actual libreadline for licensing reasons.  Libedit doesn't seem to handle unicode properly.  Installing the readline-gpl package fixes that (@tt{raco pkg install readline-gpl}).
+The repl uses the readline module for line-editing and completion.  The readline module by default uses libedit instead of the actual libreadline for licensing reasons.  Libedit doesn't seem to handle unicode properly.  Installing the readline-gpl package fixes that (@tt{raco pkg install readline-gpl}). Note: readline-gpl may need libreadline-dev in turn. See this @hyperlink["https://github.com/racket/readline-gpl/issues/3"]{issue}. (On Linux-Debian distributions you can install by (@tt{sudo apt install --yes libreadline-dev}).)
+
 
 @subsection{Interactive functions (unstable)}
 


### PR DESCRIPTION
This temporary workaround-note might be useful until this [readline-gpl installation bug](https://github.com/racket/readline-gpl/issues/3) gets solved. 
Please verify that the `rash/scribblings/rash.scrbl` gets properly generated. I'm a newbie here and I haven't had the time to have a look at the scribble. Thanks.