### PR TITLE
add for-label bindings to avoid warnings during docs build

### DIFF
--- a/shell-pipeline/scribblings/mixed-pipeline.scrbl
+++ b/shell-pipeline/scribblings/mixed-pipeline.scrbl
@@ -4,7 +4,7 @@
 (for-label
 racket/base
 racket/contract/base
-(except-in shell/mixed-pipeline run-pipeline)
+(except-in shell/mixed-pipeline run-pipeline special-redirect? stderr-capture-redirect)
 (only-in shell/pipeline run-subprocess-pipeline
                         [pipeline? shell/pipeline/pipeline?])
 (only-in shell/pipeline-macro run-pipeline)


### PR DESCRIPTION
This change avoids the warnings during the docs build:
```
raco setup: WARNING: undefined tag in <pkgs>/shell-pipeline/scribblings/shell-pipeline.scrbl:
raco setup:  ((lib "shell/mixed-pipeline.rkt") special-redirect?)
raco setup:  ((lib "shell/mixed-pipeline.rkt") stderr-capture-redirect)
```

better would be to fill in the docs for these, of course 😄 